### PR TITLE
fix(NOTASK): Route wp-packages vendors alongside wpackagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,21 @@ The default.json is used as a base config for all WordPress based Website projec
 - Group all [minor, patch, bump] **build** related `composer` packages into a single grouped pull request
 - Create individual [major] **build** related `composer` packages into single pull requests
 
-### wordpress.org, wpackagist, packagist.linchpin.com maintenance config
+### wordpress.org, wp-packages, wpackagist, packagist.linchpin.com maintenance config
+
+> Public wordpress.org plugins and themes may be sourced from either
+> [wp-packages](https://wp-packages.org) (`wp-plugin/*`, `wp-theme/*`) or the older
+> [wpackagist](https://wpackagist.org) (`wpackagist-plugin/*`, `wpackagist-theme/*`).
+> Both vendor prefixes are routed identically, so a project can migrate between them
+> without changing its Renovate config.
 
 #### WordPress Plugins
-- Group all [minor, patch, bump] **plugin** updates from `wpackagist` (wordpress.org) and `packagist.linchpin.com` into a single pull request
-- Create individual pull requests for any [major] **plugin** updates from `wpackagist` (wordpress.org) and `packagist.linchpin.com` reviewed by a human before merging
+- Group all [minor, patch, bump] **plugin** updates from `wp-packages` or `wpackagist` (wordpress.org) and `packagist.linchpin.com` into a single pull request
+- Create individual pull requests for any [major] **plugin** updates from `wp-packages` or `wpackagist` (wordpress.org) and `packagist.linchpin.com` reviewed by a human before merging
 
 #### WordPress Themes
-- Group all [minor, patch, bump] **theme** updates from `wpackagist` (wordpress.org) and `packagist.linchpin.com` into a single pull request
-- Create individual pull requests for any [major] **theme** updates from `wpackagist` (wordpress.org) and `packagist.linchpin.com` reviewed by a human before merging
+- Group all [minor, patch, bump] **theme** updates from `wp-packages` or `wpackagist` (wordpress.org) and `packagist.linchpin.com` into a single pull request
+- Create individual pull requests for any [major] **theme** updates from `wp-packages` or `wpackagist` (wordpress.org) and `packagist.linchpin.com` reviewed by a human before merging
 
 ### Linchpin Built Custom WordPress Plugins
 

--- a/default.json
+++ b/default.json
@@ -104,6 +104,8 @@
       "matchPackageNames": [
         "/^php$/",
         "!/^wpackagist/",
+        "!/^wp-plugin/",
+        "!/^wp-theme/",
         "!/^linchpin/"
       ],
       "labels": [
@@ -134,6 +136,8 @@
       ],
       "matchPackageNames": [
         "!/^wpackagist/",
+        "!/^wp-plugin/",
+        "!/^wp-theme/",
         "!/^linchpin/"
       ],
       "matchFileNames": [
@@ -163,6 +167,8 @@
       "matchPackageNames": [
         "!/^php$",
         "!/^wpackagist/",
+        "!/^wp-plugin/",
+        "!/^wp-theme/",
         "!/^linchpin/"
       ],
       "matchFileNames": [
@@ -460,6 +466,7 @@
       ],
       "matchPackageNames": [
         "wpackagist-theme/**",
+        "wp-theme/**",
         "linchpin/**theme"
       ],
       "prBodyColumns": [
@@ -493,6 +500,7 @@
       ],
       "matchPackageNames": [
         "wpackagist-theme/**",
+        "wp-theme/**",
         "linchpin/**theme"
       ],
       "prBodyColumns": [
@@ -516,7 +524,8 @@
         "major"
       ],
       "matchPackageNames": [
-        "wpackagist-plugin/**"
+        "wpackagist-plugin/**",
+        "wp-plugin/**"
       ],
       "matchManagers": [
         "composer"
@@ -549,7 +558,8 @@
         "digest"
       ],
       "matchPackageNames": [
-        "wpackagist-plugin/**"
+        "wpackagist-plugin/**",
+        "wp-plugin/**"
       ],
       "matchManagers": [
         "composer"


### PR DESCRIPTION
## Why

[wp-packages.org](https://wp-packages.org) is replacing `wpackagist.org` as the source for
public wordpress.org plugins and themes. The vendor prefixes differ:

| Old | New |
|---|---|
| `wpackagist-plugin/woocommerce` | `wp-plugin/woocommerce` |
| `wpackagist-theme/ollie` | `wp-theme/ollie` |

Seven `packageRules` in this preset route purely on the literal `wpackagist` prefix, so a
migrated project **silently** loses its WordPress routing — no error, no warning, just
wrong commit prefixes from then on.

Two things break at once:

1. The renamed packages no longer match `Plugins wordpress.org` or
   `Themes packagist.linchpin.com and wordpress.org`.
2. They also no longer match the `!/^wpackagist/` **exclusions** on `PHP Release` and
   `Composer Dependencies` (×3) — so they get swept *into* the project build group.

Net effect: wordpress.org plugin bumps arrive prefixed `build(DEP):` / `platform(DEP):`
instead of `update(PLUGIN):` / `update(THEME):`, which files them under the wrong
release-please changelog section.

`linchpin/linchpin.com` migrated on 2026-07-29 and hit exactly this. It currently carries
two local bridge rules ([linchpin.com#941](https://github.com/linchpin/linchpin.com/pull/941))
as a stopgap; once this lands those can be deleted.

## What this does

Matches **both** prefixes everywhere, so projects migrate at their own pace with no
Renovate config change and no flag day:

| Rule | Change |
|---|---|
| `Plugins wordpress.org` (major + non-major) | `+ wp-plugin/**` |
| `Themes packagist.linchpin.com and wordpress.org` (major + non-major) | `+ wp-theme/**` |
| `PHP Release`, `Composer Dependencies` (×3) | `+ !/^wp-plugin/`, `+ !/^wp-theme/` |

Also updates the README, which described the old source as the only option.

## Verification

- `renovate-config-validator default.json` → `Config validated successfully against 1 file(s)`
- Checked the new negations against `linchpin.com`'s real `composer.json`: they match
  exactly the 14 `wp-plugin/*` and 2 `wp-theme/*` packages. `wp-coding-standards/wpcs` and
  `wp-phpunit/wp-phpunit` are **not** caught and correctly stay in `Composer Dependencies`
  — worth a second look from a reviewer, since that was the main collateral risk of
  prefix-matching on `wp-`.
- Existing `wpackagist-*` behaviour is untouched; every old pattern is still present.

## Two things I deliberately did not change

- **`renovate.json` in this repo** also references `wpackagist` (lines 34, 75–76). That is
  this repo's *own* config (it only extends `config:recommended`, not `default.json`), and
  this repo has no Composer dependencies, so those rules never fire. Left alone to keep the
  diff to the published preset. Happy to fold in if you'd rather they stay consistent.
- **Pre-existing typo at `default.json` line 164**: `"!/^php$"` is missing its closing
  delimiter, so Renovate treats it as a literal package name rather than a regex and the
  negation matches nothing. Compare the correct `"!/^php$/"` at lines 330 and 364. That
  means `php` is currently *not* excluded from the non-major `Composer Dependencies` group.
  Fixing it would change grouping behaviour, so it belongs in its own PR — flagging it
  rather than sneaking it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)